### PR TITLE
Allow WithConfiguration to update settings after host creation

### DIFF
--- a/src/CQRS.AspNet.Testing.Tests/MockingTests.cs
+++ b/src/CQRS.AspNet.Testing.Tests/MockingTests.cs
@@ -40,6 +40,7 @@ public class MockExtensionsTests
         .WithConfiguration("AnotherConfigKey", "AnotherOverriddenConfigValue");
         using var client = testApplication.CreateClient();
         var result = await client.GetStringAsync("/config");
+        result.ShouldBe("SomeOverriddenConfigValue");
     }
 
     [Fact]

--- a/src/CQRS.AspNet.Testing.Tests/MockingTests.cs
+++ b/src/CQRS.AspNet.Testing.Tests/MockingTests.cs
@@ -40,7 +40,22 @@ public class MockExtensionsTests
         .WithConfiguration("AnotherConfigKey", "AnotherOverriddenConfigValue");
         using var client = testApplication.CreateClient();
         var result = await client.GetStringAsync("/config");
+    }
 
+    [Fact]
+    public async Task ShouldChangeConfigurationAfterHostCreation()
+    {
+        using var testApplication = new TestApplication<Program>()
+            .WithConfiguration("SomeConfigKey", "InitialValue");
+        using var client = testApplication.CreateClient();
+
+        var initialValue = await client.GetStringAsync("/config");
+        initialValue.ShouldBe("InitialValue");
+
+        testApplication.WithConfiguration("SomeConfigKey", "ChangedValue");
+
+        var changedValue = await client.GetStringAsync("/config");
+        changedValue.ShouldBe("ChangedValue");
     }
 
     [Fact]

--- a/src/CQRS.AspNet.Testing/TestApplication.cs
+++ b/src/CQRS.AspNet.Testing/TestApplication.cs
@@ -37,7 +37,8 @@ public class TestApplication<TEntryPoint> : WebApplicationFactory<TEntryPoint>, 
         {
             configureHostBuilderAction.Invoke(builder);
         }
-        // Added last so it takes precedence over all other providers, including WithConfiguration.
+        // Added last so it takes precedence over other configuration providers.
+        // Configuration updates made via WithConfiguration are written into this provider.
         builder.ConfigureAppConfiguration(configBuilder =>
             configBuilder.Add(new MutableConfigurationSource(_mutableConfigurationProvider)));
         var host = base.CreateHost(builder);
@@ -52,10 +53,23 @@ public class TestApplication<TEntryPoint> : WebApplicationFactory<TEntryPoint>, 
 
 internal class MutableConfigurationProvider : ConfigurationProvider
 {
+    private readonly object _lock = new();
+
     public void Update(string key, string? value)
     {
-        Data[key] = value!;
+        lock (_lock)
+        {
+            Data[key] = value;
+        }
         OnReload();
+    }
+
+    public override bool TryGet(string key, out string? value)
+    {
+        lock (_lock)
+        {
+            return Data.TryGetValue(key, out value);
+        }
     }
 }
 

--- a/src/CQRS.AspNet.Testing/TestApplication.cs
+++ b/src/CQRS.AspNet.Testing/TestApplication.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 namespace CQRS.AspNet.Testing;
@@ -10,6 +11,7 @@ namespace CQRS.AspNet.Testing;
 public class TestApplication<TEntryPoint> : WebApplicationFactory<TEntryPoint>, IHostBuilderConfiguration where TEntryPoint : class
 {
     private readonly List<Action<IHostBuilder>> _configureHostBuilderActions = new();
+    private readonly MutableConfigurationProvider _mutableConfigurationProvider = new();
 
     /// <summary>
     /// Used to configure the <see cref="IHostBuilder"/> before we start to create clients.
@@ -22,6 +24,12 @@ public class TestApplication<TEntryPoint> : WebApplicationFactory<TEntryPoint>, 
         return this;
     }
 
+    internal TestApplication<TEntryPoint> UpdateConfiguration(string key, string? value)
+    {
+        _mutableConfigurationProvider.Update(key, value);
+        return this;
+    }
+
     /// <inheritdoc />
     protected override IHost CreateHost(IHostBuilder builder)
     {
@@ -29,6 +37,9 @@ public class TestApplication<TEntryPoint> : WebApplicationFactory<TEntryPoint>, 
         {
             configureHostBuilderAction.Invoke(builder);
         }
+        // Added last so it takes precedence over all other providers, including WithConfiguration.
+        builder.ConfigureAppConfiguration(configBuilder =>
+            configBuilder.Add(new MutableConfigurationSource(_mutableConfigurationProvider)));
         var host = base.CreateHost(builder);
         return host;
     }
@@ -37,6 +48,24 @@ public class TestApplication<TEntryPoint> : WebApplicationFactory<TEntryPoint>, 
     {
         _configureHostBuilderActions.Add(configureHostBuilder);
     }
+}
+
+internal class MutableConfigurationProvider : ConfigurationProvider
+{
+    public void Update(string key, string? value)
+    {
+        Data[key] = value!;
+        OnReload();
+    }
+}
+
+internal class MutableConfigurationSource : IConfigurationSource
+{
+    private readonly MutableConfigurationProvider _provider;
+
+    public MutableConfigurationSource(MutableConfigurationProvider provider) => _provider = provider;
+
+    public IConfigurationProvider Build(IConfigurationBuilder builder) => _provider;
 }
 
 /// <summary>

--- a/src/CQRS.AspNet.Testing/TestExtensions.cs
+++ b/src/CQRS.AspNet.Testing/TestExtensions.cs
@@ -233,6 +233,8 @@ public static class TestExtensions
     /// <returns><see cref="TestApplication{TEntryPoint}"/> for chaining calls.</returns>
     public static TestApplication<TEntryPoint> WithConfiguration<TEntryPoint>(this TestApplication<TEntryPoint> testApplication, string key, string? value) where TEntryPoint : class
     {
+        testApplication.ConfigureHostBuilder(builder => builder.ConfigureHostConfiguration(configurationBuilder =>
+            configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?> { { key, value } })));
         testApplication.UpdateConfiguration(key, value);
         return testApplication;
     }

--- a/src/CQRS.AspNet.Testing/TestExtensions.cs
+++ b/src/CQRS.AspNet.Testing/TestExtensions.cs
@@ -233,8 +233,7 @@ public static class TestExtensions
     /// <returns><see cref="TestApplication{TEntryPoint}"/> for chaining calls.</returns>
     public static TestApplication<TEntryPoint> WithConfiguration<TEntryPoint>(this TestApplication<TEntryPoint> testApplication, string key, string? value) where TEntryPoint : class
     {
-        testApplication.ConfigureHostBuilder(builder => builder.ConfigureHostConfiguration(configurationBuilder => configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?> { { key, value } })));
-        testApplication.ConfigureHostBuilder(builder => builder.ConfigureAppConfiguration(configurationBuilder => configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?> { { key, value } })));
+        testApplication.UpdateConfiguration(key, value);
         return testApplication;
     }
 


### PR DESCRIPTION
## Summary

- Introduced `MutableConfigurationProvider` / `MutableConfigurationSource` that is registered last in the configuration pipeline during `CreateHost`, so it takes precedence over all other providers
- `WithConfiguration` now writes directly into this mutable provider instead of queuing `ConfigureHostBuilder` actions, making it work both before and after the host is built
- Added `ShouldChangeConfigurationAfterHostCreation` test that verifies a value can be changed via `WithConfiguration` after the client is created and that the `/config` endpoint immediately reflects the new value

## Test plan

- [ ] `ShouldChangeConfigurationAfterHostCreation` — calls `/config`, changes setting with `WithConfiguration`, calls `/config` again, asserts the new value is returned
- [ ] All existing tests continue to pass (17 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)