### PR TITLE
Reset mock when MockService is called again for the same type

### DIFF
--- a/src/CQRS.AspNet.Testing.Tests/MockingTests.cs
+++ b/src/CQRS.AspNet.Testing.Tests/MockingTests.cs
@@ -249,6 +249,28 @@ public class MockExtensionsTests
     }
 
 
+    [Fact]
+    public async Task ShouldResetMockWhenCalledTwiceOnSameTestApplication()
+    {
+        var testApplication = new TestApplication<Program>();
+
+        // First round — register before CreateClient() so the mock is wired into DI
+        var mock1 = testApplication.MockCommandHandler<TemperatureCommand>();
+        var client = testApplication.CreateClient();
+
+        await client.PostAsync("/temperatures", JsonContent.Create(new TemperatureCommand("Oslo", 10.0)));
+        mock1.VerifyCommandHandler(cmd => cmd.Value == 10.0, Times.Once());
+
+        // Second round — same instance, reset
+        var mock2 = testApplication.MockCommandHandler<TemperatureCommand>();
+        mock2.ShouldBeSameAs(mock1);
+        mock2.VerifyCommandHandler(Times.Never());
+
+        await client.PostAsync("/temperatures", JsonContent.Create(new TemperatureCommand("Oslo", 20.0)));
+        mock2.VerifyCommandHandler(cmd => cmd.Value == 20.0, Times.Once());
+        mock2.VerifyCommandHandler(cmd => cmd.Value == 10.0, Times.Never());
+    }
+
     public class Foo { }
 
 

--- a/src/CQRS.AspNet.Testing/TestExtensions.cs
+++ b/src/CQRS.AspNet.Testing/TestExtensions.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using CQRS.Command.Abstractions;
 using CQRS.Query.Abstractions;
@@ -216,9 +217,21 @@ public static class TestExtensions
         return mockHttpMessageHandler;
     }
 
+    private static readonly ConditionalWeakTable<IHostBuilderConfiguration, Dictionary<Type, object>> _mockRegistries = new();
+
     private static Mock<T> RegisterMockAsSingleton<T>(IHostBuilderConfiguration hostBuilderConfiguration) where T : class
     {
+        var registry = _mockRegistries.GetOrCreateValue(hostBuilderConfiguration);
+
+        if (registry.TryGetValue(typeof(T), out var existing))
+        {
+            var existingMock = (Mock<T>)existing;
+            existingMock.Reset();
+            return existingMock;
+        }
+
         var mock = new Mock<T>();
+        registry[typeof(T)] = mock;
         hostBuilderConfiguration.AddHostBuilderConfiguration(hb => hb.ConfigureServices(services => services.AddSingleton(mock.Object)));
         return mock;
     }


### PR DESCRIPTION
## Summary

- `RegisterMockAsSingleton<T>` now tracks registered mocks per `TestApplication` instance using a `ConditionalWeakTable<IHostBuilderConfiguration, Dictionary<Type, object>>`
- A second call to `MockService<T>` (or any of its typed wrappers) for an already-registered type returns the same `Mock<T>` instance with `Reset()` called, rather than creating and registering a new one
- This works after `CreateClient()` has been called since the mock object already registered as a singleton in DI is reset in place

## Test plan

- [ ] `ShouldResetMockWhenCalledTwiceOnSameTestApplication` verifies the returned mock is the same instance, invocations are cleared after reset, and only the new round's calls are recorded
- [ ] All 18 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)