### PR TITLE
Bump to .NET 10 and update NuGet packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "8.x"
+          dotnet-version: "10.x"
 
       - name: Install dotnet-script
         run: dotnet tool install dotnet-script -g

--- a/src/CQRS.AspNet.Testing.Example/CQRS.AspNet.Testing.Example.csproj
+++ b/src/CQRS.AspNet.Testing.Example/CQRS.AspNet.Testing.Example.csproj
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LightInject.Microsoft.Hosting" Version="2.1.0" />
-    <PackageReference Include="CQRS.LightInject" Version="1.5.1" />
+    <PackageReference Include="LightInject.Microsoft.Hosting" Version="2.2.0" />
+    <PackageReference Include="CQRS.LightInject" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/src/CQRS.AspNet.Testing.Tests/CQRS.AspNet.Testing.Tests.csproj
+++ b/src/CQRS.AspNet.Testing.Tests/CQRS.AspNet.Testing.Tests.csproj
@@ -1,22 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CQRS.AspNet.Testing/CQRS.AspNet.Testing.csproj
+++ b/src/CQRS.AspNet.Testing/CQRS.AspNet.Testing.csproj
@@ -10,7 +10,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>dotnet testing aspnet</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
@@ -18,10 +18,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageReference Include="CQRS.Query.Abstractions" Version="1.0.0" />
     <PackageReference Include="CQRS.Command.Abstractions" Version="1.2.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
-    <PackageReference Include="Scrutor" Version="6.0.1" />
+    <PackageReference Include="Scrutor" Version="7.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Target framework bumped from `net8.0` to `net10.0` across all projects
- CI workflow updated to use `dotnet-version: "10.x"`
- Updated NuGet packages:
  - `Microsoft.AspNetCore.Mvc.Testing` 8.0.12 → 10.0.8
  - `Scrutor` 6.0.1 → 7.0.0
  - `LightInject.Microsoft.Hosting` 2.1.0 → 2.2.0
  - `CQRS.LightInject` 1.5.1 → 2.1.0
  - `Microsoft.NET.Test.Sdk` 17.12.0 → 18.6.0
  - `xunit.runner.visualstudio` 3.0.1 → 3.1.5
  - `coverlet.collector` 6.0.4 → 10.0.1

## Test plan

- [x] Solution builds with 0 warnings and 0 errors
- [x] All 18 tests pass on net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)